### PR TITLE
Update haiku delete UI and status bar

### DIFF
--- a/icons/feather.svg
+++ b/icons/feather.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M3 21l18-9L3 3v6l10 3-10 3z"/>
+</svg>


### PR DESCRIPTION
## Summary
- redesign haiku delete menu with clearer instructions
- lighten Hemingway mode button and give it a new icon
- center timer menu and restrict width
- add grey separator with soft shadow and update tab indicator color
- support bullet lists and block quotes in markdown highlighter

## Testing
- `python3 -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_687a42bfd1bc83289b3d15f1b99b2868