### PR TITLE
Improve menu shortcut handling and add haiku delete fallback

### DIFF
--- a/main.py
+++ b/main.py
@@ -407,6 +407,7 @@ class TimerMenu(QtWidgets.QWidget):
     def show_menu(self):
         """Vis menuen med en let slide-animation."""
         self.setVisible(True)
+        self.raise_()
         if self.parent():
             self.setFixedWidth(int(self.parent().width() * 0.33))
         end = self.sizeHint().height()
@@ -535,7 +536,6 @@ class FileMenu(QtWidgets.QWidget):
         self.list.installEventFilter(self)
         self.line.returnPressed.connect(self._emit)
         self.list.itemActivated.connect(self._emit)
-        self.setMaximumHeight(0)
         self.hide()
 
     def setup(self, mode: str, default: str = ""):
@@ -575,6 +575,7 @@ class FileMenu(QtWidgets.QWidget):
         end = QtCore.QRect((parent.width() - width) // 2, 0, width, parent.height())
         self.setGeometry(start)
         self.setVisible(True)
+        self.raise_()
         anim = QtCore.QPropertyAnimation(self, b"geometry")
         anim.setStartValue(start)
         anim.setEndValue(end)
@@ -760,7 +761,6 @@ class DeleteMenu(QtWidgets.QWidget):
         self.layout().addLayout(btn_row)
         self.confirm_btn.hide()
 
-        self.setMaximumHeight(0)
         self.hide()
         self.installEventFilter(self)
 
@@ -774,6 +774,7 @@ class DeleteMenu(QtWidgets.QWidget):
         end = QtCore.QRect((parent.width() - width) // 2, 0, width, parent.height())
         self.setGeometry(start)
         self.setVisible(True)
+        self.raise_()
         self._set_haiku()
         for inp in self.inputs:
             inp.hide()
@@ -931,6 +932,7 @@ class PowerMenu(QtWidgets.QWidget):
         parent = self.parent()
         self.setGeometry(0, parent.height(), parent.width(), parent.height())
         self.setVisible(True)
+        self.raise_()
         wnd = self.window()
         if hasattr(wnd, "set_shortcuts_enabled"):
             wnd.set_shortcuts_enabled(False)
@@ -1191,7 +1193,10 @@ class NotatorMainWindow(QtWidgets.QMainWindow):
             ("Ctrl+Q", self.close),
             ("Ctrl+,", self.prev_tab),
             ("Ctrl+.", self.next_tab),
-            ("Ctrl+Alt+Backspace", self.request_delete),
+            # "Ctrl+Alt+Backspace" bruges traditionelt til at dr\u00e6be X11 og
+            # kan derfor v\u00e6re deaktiveret p\u00e5 nogle systemer. Vi registrerer
+            # derfor ogs\u00e5 en reserve-genvej.
+            (["Ctrl+Alt+Backspace", "Ctrl+Alt+D"], self.request_delete),
             ("Ctrl+T", self.toggle_timer),
             ("Ctrl+R", self.reset_or_stop_timer),
             ("Ctrl+H", self.toggle_hemingway),
@@ -1201,11 +1206,14 @@ class NotatorMainWindow(QtWidgets.QMainWindow):
             ("Ctrl+Escape", self.power_menu.show_menu),
         ]
         self.shortcuts = []
-        for seq, slot in shortcuts:
-            sc = QtGui.QShortcut(QtGui.QKeySequence(seq), self)
-            sc.setContext(QtCore.Qt.ShortcutContext.ApplicationShortcut)
-            sc.activated.connect(slot)
-            self.shortcuts.append(sc)
+        for seqs, slot in shortcuts:
+            sequences = seqs if isinstance(seqs, (list, tuple)) else [seqs]
+            for seq in sequences:
+                sc = QtGui.QShortcut(QtGui.QKeySequence(seq), self)
+                sc.setContext(QtCore.Qt.ShortcutContext.ApplicationShortcut)
+                sc.setAutoRepeat(False)
+                sc.activated.connect(slot)
+                self.shortcuts.append(sc)
 
     def set_shortcuts_enabled(self, enabled: bool) -> None:
         """Aktiver eller deaktiver alle globale genveje."""


### PR DESCRIPTION
## Summary
- Register shortcuts with non-repeating `QShortcut` objects so open/save, delete and timer menus react reliably
- Provide alternative `Ctrl+Alt+D` shortcut for haiku deletion when `Ctrl+Alt+Backspace` is unavailable
- Raise overlay menus when shown so file, delete and power overlays appear above the editor
- Remove zero-height constraints so file and haiku delete menus actually display when triggered

## Testing
- `python -m py_compile main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bc26cdec883288becceb84b9947df