### PR TITLE
Fix missing think menu checkbox

### DIFF
--- a/main.py
+++ b/main.py
@@ -1083,6 +1083,9 @@ class MindMenu(QtWidgets.QWidget):
         self.hemi_cb = QtWidgets.QCheckBox("Hemmingway mode")
         self.layout().addWidget(self.hemi_cb)
 
+        self.think_cb = QtWidgets.QCheckBox("Tænkepauser")
+        self.layout().addWidget(self.think_cb)
+
         self.predict_cb = QtWidgets.QCheckBox("Ordforsagelse")
         self.layout().addWidget(self.predict_cb)
 


### PR DESCRIPTION
## Summary
- add missing Think pause checkbox to MindMenu so toggledThink works

## Testing
- `python3 -m py_compile main.py`
- `python3 - <<'PY'
import os
os.environ['QT_QPA_PLATFORM']='offscreen'
from PyQt6 import QtWidgets
from main import MindMenu
app = QtWidgets.QApplication([])
mm = MindMenu()
print('has think_cb', hasattr(mm,'think_cb'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a64d70780c83288994fdfcfbc45c1b